### PR TITLE
emit es6 and drop es6-promise typings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: node_js
+node_js:
+- '6'
+env:
+  global:
+  - SAUCE_USERNAME: dojo2-ts-ci
+  - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
+cache:
+  directories:
+  - node_modules
+install:
+- travis_retry npm install grunt cli
+- travis_retry npm install
+script:
+- grunt
+- grunt intern:node --combined
+- grunt remapIstanbul:ci
+- grunt uploadCoverage
+notifications:
+  slack:
+    secure: O9m3cCkl3H8VXRIuKLFfx91C01n9yLlehem9K3snnBMiyrtGWR2aXo+t1eeZYGfFWIl8UBEaSPlDurI1KspIcW/JbszuYAVje21rbl+ptkp008f5gDVfFCFpqdM9S5+lrVJLlx1mrikWKBRsjYqZHYV9EJx/ss+P86JsQ0utC7zgBFYId+UCMybAemzi1FPfeULFWpoi8QavoN8fNr4yHBayrqOlqnnIhlYLoTiGL6yY8L/meUrmWVxSY3JMDxLeIYNppt4puvTGUD1hU2LZgFZp1y6jGMcAlZI5amGV+iyTl/h2w1wiB6q5tolJ1JslosFvh53y7+1Crbm8wQDkX42+z7Rn3/jXRUBFwLZBGZQ99FcE0Yz+XBaQA3GuCgPNd0rcHmJxeYAKMm7jg2B8Nzd6It3q5mjdp9ITA5kR2G7g+iH8R4y112FXCpvt4/RUvHuyhl7w8lFlHK+LslH3DBjDi3fKUuwiGtU8oD3xpCunJ4JUgQmAWIOy3mpFIOX4QPcBKqByp10fNw3G73JDsJ9DXrFGb/+WnA2OgpDnKOnjoporwufRZLeioRwCJAWM0DbFDvRc1mbnECwcKiedzKdTxSWUGyJ6sxKydZtC11tF356BkzIsf3x7cKSed2LI8VXYNiPOJu9P+/s5/jRf/7kZ+i2ETfuKZC2awhgkBGo=
+    on_success: change

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "yargs": "^5.0.0"
   },
   "dependencies": {
-    "@types/es6-promise": "0.0.32",
     "copy-webpack-plugin": "^3.0.1",
     "html-webpack-plugin": "^2.22.0",
     "ts-loader": "^0.8.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.0",
+	"version": "2.0.3",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
@@ -9,7 +9,7 @@
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es5",
+		"target": "es6",
 		"moduleResolution": "node"
 	},
 	"include": [


### PR DESCRIPTION
Update to emit es6 and remove `es6-promise` typings.

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

