### PR TITLE
Add stylus support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,13 @@
   },
   "dependencies": {
     "copy-webpack-plugin": "^3.0.1",
+    "css-loader": "^0.25.0",
+    "file-loader": "^0.9.0",
+    "html-loader": "^0.4.4",
     "html-webpack-plugin": "^2.22.0",
+    "style-loader": "^0.13.1",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^2.3.1",
     "ts-loader": "^0.8.2",
     "umd-compat-webpack-plugin": "1.0.2",
     "webpack": "^1.13.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,9 @@ interface WebpackOptions {
 
 function watch(config: any, options: WebpackOptions, args: BuildArgs): Promise<any> {
 	config.devtool = 'eval-source-map';
-	config.entry.unshift('webpack-dev-server/client?');
+	Object.keys(config.entry).forEach((key) => {
+		config.entry[key].unshift('webpack-dev-server/client?');
+	});
 
 	const compiler = webpack(config);
 	const server = new WebpackDevServer(compiler, options);

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -6,7 +6,12 @@ const path = require('path');
 const basePath = process.cwd();
 
 module.exports = {
-	entry: [ path.join(basePath, 'src/main.ts') ],
+	entry: {
+		'src/main': [
+			path.join(basePath, 'src/main.styl'),
+			path.join(basePath, 'src/main.ts')
+		]
+	},
 	devtool: 'source-map',
 	resolve: {
 		root: [ basePath ],
@@ -24,7 +29,10 @@ module.exports = {
 		exprContextRegExp: /$^/,
 		exprContextCritical: false,
 		loaders: [
-			{ test: /src\/.*\.ts?$/, loader: 'ts-loader' }
+			{ test: /src\/.*\.ts?$/, loader: 'ts-loader' },
+			{ test: /\.html$/, loader: "html" },
+			{ test: /\.(jpe|jpg|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file' },
+			{ test: /\.styl$/, loader: 'style-loader!css-loader!stylus-loader' }
 		]
 	},
 	plugins: [
@@ -36,11 +44,12 @@ module.exports = {
 		new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false }}),
 		new HtmlWebpackPlugin ({
 			inject: true,
+			chunks: [ 'src/main' ],
 			template: 'src/index.html'
 		})
 	],
 	output: {
 		path: path.resolve('./dist'),
-		filename: 'main.js'
+		filename: '[name].js'
 	}
 };

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -46,6 +46,8 @@ export default class MockModule {
 				if (typeof dependency[prop] === 'function') {
 					mock[prop] = function () {};
 					this.sandbox.stub(mock, prop);
+				} else {
+					mock[prop] = dependency[prop];
 				}
 			}
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -18,9 +18,6 @@ describe('main', () => {
 		mockModule.dependencies(['./webpack.config', 'webpack', 'webpack-dev-server']);
 		mockWebpack = mockModule.getMock('webpack');
 		mockWebpackConfig = mockModule.getMock('./webpack.config');
-		mockWebpackConfig.entry = {
-			'src/main': []
-		};
 		moduleUnderTest = mockModule.getModuleUnderTest().default;
 		sandbox.stub(console, 'log');
 	});
@@ -71,10 +68,7 @@ describe('main', () => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce);
 			assert.isTrue((<sinon.SinonStub> console.log).firstCall.calledWith('Starting server on http://localhost:9999'));
 			assert.equal(mockWebpackConfig.devtool, 'eval-source-map');
-			assert.deepEqual(
-				mockWebpackConfig.entry,
-				{ 'src/main': ['webpack-dev-server/client?'] }
-			);
+			assert.equal(mockWebpackConfig.entry['src/main'][0], 'webpack-dev-server/client?');
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -18,7 +18,9 @@ describe('main', () => {
 		mockModule.dependencies(['./webpack.config', 'webpack', 'webpack-dev-server']);
 		mockWebpack = mockModule.getMock('webpack');
 		mockWebpackConfig = mockModule.getMock('./webpack.config');
-		mockWebpackConfig.entry = [];
+		mockWebpackConfig.entry = {
+			'src/main': []
+		};
 		moduleUnderTest = mockModule.getModuleUnderTest().default;
 		sandbox.stub(console, 'log');
 	});
@@ -71,7 +73,7 @@ describe('main', () => {
 			assert.equal(mockWebpackConfig.devtool, 'eval-source-map');
 			assert.deepEqual(
 				mockWebpackConfig.entry,
-				['webpack-dev-server/client?']
+				{ 'src/main': ['webpack-dev-server/client?'] }
 			);
 		});
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves https://github.com/dojo/cli-build/issues/6

Mostly just webpack config additions. Will automatically load `main.styl` in the the `src` folder, any generated css will currently be included in the js bundle. Further enhancements would be to use the ExtractTextPlugin to put this back as an external css file. 
