### PR TITLE
Support sourcemaps for dojo 2 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "file-loader": "^0.9.0",
     "html-loader": "^0.4.4",
     "html-webpack-plugin": "^2.22.0",
+    "source-map-loader": "zerkalica/source-map-loader#6c8872f",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",
     "stylus-loader": "^2.3.1",

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -28,6 +28,12 @@ module.exports = {
 		unknownContextCritical: false,
 		exprContextRegExp: /$^/,
 		exprContextCritical: false,
+		preLoaders: [
+			{
+				test: /dojo-.*\.js$/,
+				loader: 'source-map-loader'
+			}
+		],
 		loaders: [
 			{ test: /src\/.*\.ts?$/, loader: 'ts-loader' },
 			{ test: /\.html$/, loader: "html" },


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

Adds support of sourcemaps back to original TS (rather than just the unminified JS) for our dojo 2 dependencies. Unfortunately the official webpack source-map-loader looks dead as a project, with an outstanding PR that fixes up the sourcemap source paths, so I've had to use a fork.

