### PR TITLE
Extract CSS to separate file rather than loading from bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "copy-webpack-plugin": "^3.0.1",
     "css-loader": "^0.25.0",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-loader": "^0.4.4",
     "html-webpack-plugin": "^2.22.0",
@@ -44,7 +45,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.3.1",
     "ts-loader": "^0.8.2",
-    "umd-compat-webpack-plugin": "1.0.2",
+    "umd-compat-webpack-plugin": "1.0.4",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"
   }

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const RequirePlugin = require('umd-compat-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 const basePath = process.cwd();
 
@@ -38,10 +39,11 @@ module.exports = {
 			{ test: /src\/.*\.ts?$/, loader: 'ts-loader' },
 			{ test: /\.html$/, loader: "html" },
 			{ test: /\.(jpe|jpg|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file' },
-			{ test: /\.styl$/, loader: 'style-loader!css-loader!stylus-loader' }
+			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) }
 		]
 	},
 	plugins: [
+		new ExtractTextPlugin('main.css'),
 		new CopyWebpackPlugin([
 			{ context: 'src', from: '**/*', ignore: '*.ts' },
 		]),


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

Fixes https://github.com/dojo/cli-build/issues/9

Styles are now extracted to a separate `main.css` file, and source maps are generated. The html link tag for the stylesheet will be automatically injected by the HTML plugin.

