### PR TITLE
CSS Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,18 @@
     "yargs": "^5.0.0"
   },
   "dependencies": {
+    "async": "^2.1.2",
+    "chalk": "^1.1.3",
     "copy-webpack-plugin": "^3.0.1",
     "css-loader": "^0.25.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "globby": "^6.1.0",
     "html-loader": "^0.4.4",
     "html-webpack-plugin": "^2.22.0",
+    "mkdirp": "^0.5.1",
+    "postcss-modules": "^0.5.2",
+    "read-file-stdin": "^0.2.1",
     "source-map-loader": "zerkalica/source-map-loader#6c8872f",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",

--- a/src/cssModules.ts
+++ b/src/cssModules.ts
@@ -67,16 +67,20 @@ export default function modularize(root: string, cssOut: string, tsOut: string):
 
 	const processor: any = postcss([
 		cssModules({
-			getJSON: function(cssFileName: string, json: string) {
+			getJSON: function(cssFileName: string, json: any) {
 				if (!tsOut) {
 					return;
 				}
 
 				mkdirp(tsOut, function () {
 					const filename = path.basename(cssFileName, '.css');
+					const lines = Object.keys(json).map(function (className: string) {
+						return `export const ${ className } = '${ json[className] }'\n`;
+					});
+					lines.unshift(`/* tslint:disable:object-literal-key-quotes quotemark whitespace */\n`);
 					fs.writeFileSync(
 						`${ tsOut || '.' }/${ filename }.ts`,
-						`/* tslint:disable:object-literal-key-quotes quotemark whitespace */\nexport default ${ JSON.stringify(json) };\n`
+						lines.join('')
 					);
 				});
 			}

--- a/src/cssModules.ts
+++ b/src/cssModules.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as path from 'path';
+const postcss: any = require('postcss');
+const cssModules: any = require('postcss-modules');
+const read: any = require('read-file-stdin');
+const globby: any = require('globby');
+const async: any = require('async');
+const mkdirp: any = require('mkdirp');
+const chalk: any = require('chalk');
+
+interface PostcssArgs {
+	root: string;
+	cssOut: string;
+	tsOut: string;
+}
+
+function processFile(args: PostcssArgs, processor: any, file: string, done: Function): void {
+	const outputPath: string = path.join(args.cssOut || '', path.basename(file));
+
+	function execute(css: string, done: Function): void {
+		function complete(result: any) {
+			if (typeof result.warnings === 'function') {
+				result.warnings().forEach(function (warning: any) {
+					console.warn(warning.toString());
+				});
+			}
+			done(null, result);
+		};
+
+		const result: any = processor.process(css, { from: file, to: outputPath });
+
+		if (typeof result.then === 'function') {
+			result.then(complete).catch(done);
+		}
+		else {
+			process.nextTick(complete.bind(null, result));
+		}
+	};
+
+	function write(name: string, content: any, done: Function): void {
+		async.parallel([
+			async.apply(function(name: string, content: string, done: Function) {
+				mkdirp(path.dirname(name), function(err: any) {
+					if (err) {
+						done(err);
+					}
+					else if (args.cssOut) {
+						fs.writeFile(name, content, done);
+						console.log(chalk.green(name));
+					} else {
+						done();
+					}
+				});
+			}, name, content.css)
+		], done);
+	};
+
+	async.waterfall([
+		async.apply(read, file),
+		execute,
+		async.apply(write, outputPath)
+	], done);
+}
+
+export default function modularize(root: string, cssOut: string, tsOut: string): Promise<any> {
+	const processor: any = postcss([
+		cssModules({
+			getJSON: function(cssFileName: string, json: string) {
+				if (!tsOut) {
+					return;
+				}
+				const filename = path.basename(cssFileName, '.css');
+				fs.writeFileSync(
+					`${ tsOut || '.' }/${ filename }.ts`,
+					`/* tslint:disable:object-literal-key-quotes quotemark whitespace */\nexport default ${ JSON.stringify(json) };\n`
+				);
+			}
+		})
+	]);
+
+	const inputFiles: string[] = globby.sync(root);
+
+	return new Promise((resolve, reject) => {
+		async.each(inputFiles, processFile.bind(null, { root: root, cssOut: cssOut, tsOut: tsOut }, processor), function(err: any) {
+			if (err) {
+				reject(err);
+				return;
+			}
+			console.log('\nDone!');
+			resolve({});
+		});
+	});
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Command, Helper } from 'dojo-cli/interfaces';
 import { Argv } from 'yargs';
+import cssModularize from './cssModules';
 const webpack: any = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');
 const config: any = require('./webpack.config');
@@ -77,11 +78,16 @@ const command: Command = {
 			}
 		};
 
+		const css = cssModularize(config.cssModules.root, config.cssModules.cssOut, config.cssModules.tsOut);
 		if (args.watch) {
-			return watch(config, options, args);
+			return css.then(() => {
+				return watch(config, options, args);
+			});
 		}
 		else {
-			return compile(config, options);
+			return css.then(() => {
+				return compile(config, options);
+			});
 		}
 	}
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -61,8 +61,8 @@ module.exports = {
 		filename: '[name].js'
 	},
 	cssModules: {
-		root: 'src/styles/structural/*.css',
-		cssOut: 'src/styles/structural/_css/',
-		tsOut: 'src/styles/structural/_modules/'
+		root: path.join(basePath, 'src/styles/structural/*.css'),
+		cssOut: path.join(basePath, 'src/styles/structural/_css/'),
+		tsOut: path.join(basePath, 'src/styles/structural/_modules/)'
 	}
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -63,6 +63,6 @@ module.exports = {
 	cssModules: {
 		root: path.join(basePath, 'src/styles/structural/*.css'),
 		cssOut: path.join(basePath, 'src/styles/structural/_css/'),
-		tsOut: path.join(basePath, 'src/styles/structural/_modules/)'
+		tsOut: path.join(basePath, 'src/styles/structural/_modules/')
 	}
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -59,5 +59,10 @@ module.exports = {
 	output: {
 		path: path.resolve('./dist'),
 		filename: '[name].js'
+	},
+	cssModules: {
+		root: 'src/styles/structural/*.css',
+		cssOut: 'src/styles/structural/_css/',
+		tsOut: 'src/styles/structural/_modules/'
 	}
 };


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR adds optional CSS module compilation to the build command. After some discussion with @matt-gadd, @kitsonk, and @agubler, this seemed to make more sense than a separate CSS module CLI command. Note that an intermediary `dojo css typings` command has been developed at https://github.com/bitpshr/cli-css-typings that would theoretically be used during development in order to leverage intellisense.

A user may specify a `cssModules` config in the webpack configuration file:

```js
// ...
cssModules: {
    root: path.join(basePath, 'src/styles/structural/*.css'),
    cssOut: path.join(basePath, 'src/styles/structural/_css/'),
    tsOut: path.join(basePath, 'src/styles/structural/_modules/')
}
// ...
```

Resolves dojo/widgets#67, dojo/cli#61, dojo/widgets#66, dojo/meta#28
