### PR TITLE
Make webpack resource paths more readable

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
 		loaders: [
 			{ test: /src[\\\/].*\.ts?$/, loader: 'ts-loader' },
 			{ test: /\.html$/, loader: "html" },
-			{ test: /\.(jpe|jpg|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file' },
+			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
 			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) }
 		]
 	},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

Makes the filenames for resources generated by webpack more readable (previously were just hashes). Also now retains the original folder structure of the files also.

