### PR TITLE
Enable CSS module support

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -37,9 +37,10 @@ module.exports = {
 		],
 		loaders: [
 			{ test: /src[\\\/].*\.ts?$/, loader: 'ts-loader' },
-			{ test: /\.html$/, loader: "html" },
+			{ test: /\.html$/, loader: 'html' },
 			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
-			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) }
+			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
+			{ test: /\.css$/, loader: 'style-loader!css-loader?modules' },
 		]
 	},
 	plugins: [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR adds CSS module support to the build command. It makes use of [webpack/css-loader](https://github.com/webpack/css-loader) for CSS compilation and inlining rather than relying on a custom plugin or loader. It's probably easiest to walk through an example development flow for an end user:

1. Generate a Dojo 2 app.
```
dojo create app --name testApp
```

2. Create a CSS module at `testApp/src/styles/example.css` (file name and location don't matter).
```css
.someClass {
	background: red;
}
```

3. Generate typings to leverage TS intellisense (using dojo/cli-css-typings#3). A type declaration file will be generated at `testApp/src/styles/module.css.d.ts`.
```
dojo css typings --out testApp/src/styles/ testApp/src/styles/example.css
```

4. Import styles and do something with them. Here we import the CSS module into `testApp/src/main.ts` and apply the generated class to the `<body>` element as a demonstration, but ideally a user would import CSS modules into widgets.
```ts
import * as css from './styles/example.css';
document.body.classList.add(css.someClass);
```

5. Build the app.
```
cd testApp
dojo build webpack
```

6. Serve `testApp/dist` and visit in a browser. The `<body>` should have a generated CSS class name and a red background.

Resolves dojo/widgets#67, dojo/cli#61, dojo/widgets#66, dojo/meta#28

