### PR TITLE
Use umd-compat-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.3.1",
     "ts-loader": "^1.0.0",
-    "umd-compat-webpack-plugin": "1.0.4",
+    "umd-compat-loader": "^1.0.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"
   }

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -1,5 +1,4 @@
 const webpack = require('webpack');
-const RequirePlugin = require('umd-compat-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -25,10 +24,6 @@ module.exports = {
 		root: [ path.join(__dirname, 'node_modules') ]
 	},
 	module: {
-		unknownContextRegExp: /$^/,
-		unknownContextCritical: false,
-		exprContextRegExp: /$^/,
-		exprContextCritical: false,
 		preLoaders: [
 			{
 				test: /dojo-.*\.js$/,
@@ -36,7 +31,8 @@ module.exports = {
 			}
 		],
 		loaders: [
-			{ test: /src[\\\/].*\.ts?$/, loader: 'ts-loader' },
+			{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
+			{ test: /\.js?$/, loader: 'umd-compat-loader' },
 			{ test: /\.html$/, loader: 'html' },
 			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
 			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
@@ -44,11 +40,11 @@ module.exports = {
 		]
 	},
 	plugins: [
+		new webpack.ContextReplacementPlugin(/dojo-app\/lib/, { test: () => false }),
 		new ExtractTextPlugin('main.css'),
 		new CopyWebpackPlugin([
 			{ context: 'src', from: '**/*', ignore: '*.ts' },
 		]),
-		new RequirePlugin(),
 		new webpack.optimize.DedupePlugin(),
 		new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false }}),
 		new HtmlWebpackPlugin ({


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

This replaces my very hacky webpack plugin, with my slightly less hacky webpack loader. The loader sniffs for the TypeScript UMD style, it then uses recast to modify the AST which means the source map is correct after modifications.

This should now mean we can leverage lazy requires (like `require.context`, and `require(someVar)`), which before we couldn't do with the umd-compat-plugin, as you had to ignore them and require became a no-op.

As a side effect, I've now had to add an ignore context for `dojo/app`, as webpack now picks up the dynamic require.