### PR TITLE
Enable Stylus support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ interface WebpackOptions {
 }
 
 function watch(config: any, options: WebpackOptions, args: BuildArgs): Promise<any> {
-	config.devtool = 'eval-source-map';
+	config.devtool = 'inline-source-map';
 	Object.keys(config.entry).forEach((key) => {
 		config.entry[key].unshift('webpack-dev-server/client?');
 	});

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -32,26 +32,19 @@ module.exports = {
 			}
 		],
 		loaders: [
+			{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
+			{ test: /\.js?$/, loader: 'umd-compat-loader'  },
+			{ test: /\.html$/, loader: 'html' },
+			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
 			{
-				test: /src[\\\/].*\.ts?$/,
-				loader: 'umd-compat-loader!ts-loader'
-			}, {
-				test: /\.js?$/, 
-				loader: 'umd-compat-loader' 
-			}, {
-				test: /\.html$/,
-				loader: 'html' 
-			}, {
-				test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/,
-				loader: 'file?name=[path][name].[hash:6].[ext]'
-			}, {
 				test: /\.styl$/,
 				exclude: /\.module\.styl$/,
 				loader: ExtractTextPlugin.extract([
 					'css-loader?sourceMap',
 					'stylus-loader'
 				])
-			}, {
+			},
+			{
 				test: /\.module\.styl$/,
 				loader: ExtractTextPlugin.extract([
 					`css-loader?modules&sourceMap&importLoaders=1&localIdentName=${cssModuleIdent}`,

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -5,6 +5,11 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 const basePath = process.cwd();
 const cssModuleIdent = '[name]__[local]__[hash:base64:5]';
+const stylusLoader = ExtractTextPlugin.extract([ 'css-loader?sourceMap', 'stylus-loader?sourceMap' ]);
+const cssLoader = ExtractTextPlugin.extract([
+	`css-loader?modules&sourceMap&localIdentName=${cssModuleIdent}`,
+	'stylus-loader?sourceMap'
+]);
 
 module.exports = {
 	entry: {
@@ -33,24 +38,11 @@ module.exports = {
 		],
 		loaders: [
 			{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
-			{ test: /\.js?$/, loader: 'umd-compat-loader'  },
+			{ test: /\.js?$/, loader: 'umd-compat-loader' },
 			{ test: /\.html$/, loader: 'html' },
 			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
-			{
-				test: /\.styl$/,
-				exclude: /\.module\.styl$/,
-				loader: ExtractTextPlugin.extract([
-					'css-loader?sourceMap',
-					'stylus-loader'
-				])
-			},
-			{
-				test: /\.module\.styl$/,
-				loader: ExtractTextPlugin.extract([
-					`css-loader?modules&sourceMap&importLoaders=1&localIdentName=${cssModuleIdent}`,
-					'stylus-loader'
-				])
-			}
+			{ test: /\.styl$/, exclude: /\.module\.styl$/, loader: stylusLoader },
+			{ test: /\.module\.styl$/, loader: cssLoader }
 		]
 	},
 	plugins: [

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -35,8 +35,8 @@ module.exports = {
 			{ test: /\.js?$/, loader: 'umd-compat-loader' },
 			{ test: /\.html$/, loader: 'html' },
 			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
-			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
-			{ test: /\.css$/, loader: 'style-loader!css-loader?modules' },
+			{ test: /src[\\\/]main\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
+			{ test: /structural[\\\/].*\.styl$/, loader: 'style-loader!css-loader?modules!stylus-loader' },
 		]
 	},
 	plugins: [

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 const basePath = process.cwd();
+const cssModuleIdent = '[name]__[local]__[hash:base64:5]';
 
 module.exports = {
 	entry: {
@@ -31,12 +32,32 @@ module.exports = {
 			}
 		],
 		loaders: [
-			{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
-			{ test: /\.js?$/, loader: 'umd-compat-loader' },
-			{ test: /\.html$/, loader: 'html' },
-			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
-			{ test: /\.styl$/, exclude: /\.module\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
-			{ test: /\.module\.styl$/, loader: 'style-loader!css-loader?modules!stylus-loader' }
+			{
+				test: /src[\\\/].*\.ts?$/,
+				loader: 'umd-compat-loader!ts-loader'
+			}, {
+				test: /\.js?$/, 
+				loader: 'umd-compat-loader' 
+			}, {
+				test: /\.html$/,
+				loader: 'html' 
+			}, {
+				test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/,
+				loader: 'file?name=[path][name].[hash:6].[ext]'
+			}, {
+				test: /\.styl$/,
+				exclude: /\.module\.styl$/,
+				loader: ExtractTextPlugin.extract([
+					'css-loader?sourceMap',
+					'stylus-loader'
+				])
+			}, {
+				test: /\.module\.styl$/,
+				loader: ExtractTextPlugin.extract([
+					`css-loader?modules&sourceMap&importLoaders=1&localIdentName=${cssModuleIdent}`,
+					'stylus-loader'
+				])
+			}
 		]
 	},
 	plugins: [

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
 			{ test: /\.html$/, loader: 'html' },
 			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
 			{ test: /src[\\\/]main\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
-			{ test: /structural[\\\/].*\.styl$/, loader: 'style-loader!css-loader?modules!stylus-loader' },
+			{ test: /\.module\.styl$/, loader: 'style-loader!css-loader?modules!stylus-loader' },
 		]
 	},
 	plugins: [

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -35,8 +35,8 @@ module.exports = {
 			{ test: /\.js?$/, loader: 'umd-compat-loader' },
 			{ test: /\.html$/, loader: 'html' },
 			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
-			{ test: /src[\\\/]main\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
-			{ test: /\.module\.styl$/, loader: 'style-loader!css-loader?modules!stylus-loader' },
+			{ test: /\.styl$/, exclude: /\.module\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
+			{ test: /\.module\.styl$/, loader: 'style-loader!css-loader?modules!stylus-loader' }
 		]
 	},
 	plugins: [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR modifies the webpack config so CSS modules can be written in Stylus and depends on dojo/cli-css-typings#5. Note that to differentiate between regular `.styl` files and CSS module `.styl` files, by convention, CSS module names should end in `.module.styl`, e.g. `example.module.styl`.

Resolves #19 

