### PR TITLE
Make regex safe for Windows

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
 		]
 	},
 	plugins: [
-		new webpack.ContextReplacementPlugin(/dojo-app\/lib/, { test: () => false }),
+		new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 		new ExtractTextPlugin('main.css'),
 		new CopyWebpackPlugin([
 			{ context: 'src', from: '**/*', ignore: '*.ts' },


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixes the regex used when configuring the `ContextReplacementPlugin`

Resolves #23

