### PR TITLE
Fix help so it displays per grouping

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ function compile(config: any, options: WebpackOptions): Promise<any> {
 
 const command: Command = {
 	description: 'create a build of your application',
-	register(helper: Helper, options: OptionsHelper): void {
+	register(options: OptionsHelper): void {
 		options('w', {
 			alias: 'watch',
 			describe: 'watch and serve'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Command, Helper, OptionsHelper } from 'dojo-cli/interfaces';
-import { Argv, Options } from 'yargs';
+import { Argv } from 'yargs';
 const webpack: any = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');
 const config: any = require('./webpack.config');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Command, Helper, OptionsHelper } from 'dojo-cli/interfaces';
+import { Command, Helper, OptionsHelper } from '@dojo/cli/interfaces';
 import { Argv } from 'yargs';
 const webpack: any = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Command, Helper } from 'dojo-cli/interfaces';
+import { Command, Helper, OptionsHelper } from 'dojo-cli/interfaces';
 import { Argv, Options } from 'yargs';
 const webpack: any = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');
@@ -77,7 +77,7 @@ function compile(config: any, options: WebpackOptions): Promise<any> {
 
 const command: Command = {
 	description: 'create a build of your application',
-	register(options: (key: string, options: Options) => void): void {
+	register(helper: Helper, options: OptionsHelper): void {
 		options('w', {
 			alias: 'watch',
 			describe: 'watch and serve'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import { Command, Helper } from '@dojo/cli/interfaces';
-import { Argv } from 'yargs';
+import { Command, Helper } from 'dojo-cli/interfaces';
+import { Argv, Options } from 'yargs';
 const webpack: any = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');
 const config: any = require('./webpack.config');
@@ -77,39 +77,37 @@ function compile(config: any, options: WebpackOptions): Promise<any> {
 
 const command: Command = {
 	description: 'create a build of your application',
-	register(helper: Helper) {
-		helper.yargs.option('w', {
+	register(options: (key: string, options: Options) => void): void {
+		options('w', {
 			alias: 'watch',
 			describe: 'watch and serve'
 		});
 
-		helper.yargs.option('p', {
+		options('p', {
 			alias: 'port',
 			describe: 'port to serve on when using --watch',
 			type: 'number'
 		});
 
-		helper.yargs.option('t', {
+		options('t', {
 			alias: 'with-tests',
 			describe: 'build tests as well as sources'
 		});
 
-		helper.yargs.option('locale', {
+		options('locale', {
 			describe: 'The default locale for the application',
 			type: 'string'
 		});
 
-		helper.yargs.option('supportedLocales', {
+		options('supportedLocales', {
 			describe: 'Any additional locales supported by the application',
 			type: 'array'
 		});
 
-		helper.yargs.option('messageBundles', {
+		options('messageBundles', {
 			describe: 'Any message bundles to include in the build',
 			type: 'array'
 		});
-
-		return helper.yargs;
 	},
 	run(helper: Helper, args: BuildArgs) {
 		const options: WebpackOptions = {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -39,7 +39,7 @@ describe('main', () => {
 
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
-		moduleUnderTest.register(null, options);
+		moduleUnderTest.register(options);
 		assert.deepEqual(
 			options.firstCall.args,
 			[ 'w', { alias: 'watch', describe: 'watch and serve' } ]

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -38,14 +38,14 @@ describe('main', () => {
 	});
 
 	it('should register supported arguments', () => {
-		const helper = { yargs: { option: sandbox.stub() } };
-		moduleUnderTest.register(helper);
+		const options = sandbox.stub();
+		moduleUnderTest.register(options);
 		assert.deepEqual(
-			helper.yargs.option.firstCall.args,
+			options.firstCall.args,
 			[ 'w', { alias: 'watch', describe: 'watch and serve' } ]
 		);
 		assert.deepEqual(
-			helper.yargs.option.secondCall.args,
+			options.secondCall.args,
 			[ 'p', { alias: 'port', describe: 'port to serve on when using --watch', type: 'number' }],
 		);
 		assert.deepEqual(

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -39,7 +39,7 @@ describe('main', () => {
 
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
-		moduleUnderTest.register(options);
+		moduleUnderTest.register(null, options);
 		assert.deepEqual(
 			options.firstCall.args,
 			[ 'w', { alias: 'watch', describe: 'watch and serve' } ]

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -49,19 +49,19 @@ describe('main', () => {
 			[ 'p', { alias: 'port', describe: 'port to serve on when using --watch', type: 'number' }],
 		);
 		assert.deepEqual(
-			helper.yargs.option.thirdCall.args,
+			options.thirdCall.args,
 			[ 't', { alias: 'with-tests', describe: 'build tests as well as sources' }]
 		);
 		assert.deepEqual(
-			helper.yargs.option.args[3],
+			options.args[3],
 			[ 'locale', { describe: 'The default locale for the application', type: 'string' }],
 		);
 		assert.deepEqual(
-			helper.yargs.option.args[4],
+			options.args[4],
 			[ 'supportedLocales', { describe: 'Any additional locales supported by the application', type: 'array' }]
 		);
 		assert.deepEqual(
-			helper.yargs.option.args[5],
+			options.args[5],
 			[ 'messageBundles', { describe: 'Any message bundles to include in the build', type: 'array' }]
 		);
 	});


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Fix help display so that it displays options per grouping

**Related Issue:** #58

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged