### PR TITLE
Bundle size reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ts-loader": "^1.0.0",
     "umd-compat-loader": "^1.0.1",
     "webpack": "^1.13.2",
+    "webpack-bundle-analyzer-sunburst": "^1.2.0",
     "webpack-dev-server": "^1.16.1"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,10 +78,10 @@ const command: Command = {
 		};
 
 		if (args.watch) {
-			return watch(config, options, args);
+			return watch(config({ watch: true }), options, args);
 		}
 		else {
-			return compile(config, options);
+			return compile(config(), options);
 		}
 	}
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -2,44 +2,14 @@ const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer-sunburst').BundleAnalyzerPlugin;
 const path = require('path');
 const basePath = process.cwd();
 
-module.exports = {
-	entry: {
-		'src/main': [
-			path.join(basePath, 'src/main.styl'),
-			path.join(basePath, 'src/main.ts')
-		]
-	},
-	devtool: 'source-map',
-	resolve: {
-		root: [ basePath ],
-		extensions: ['', '.ts', '.tsx', '.js'],
-		alias: {
-			rxjs: '@reactivex/rxjs/dist/amd'
-		}
-	},
-	resolveLoader: {
-		root: [ path.join(__dirname, 'node_modules') ]
-	},
-	module: {
-		preLoaders: [
-			{
-				test: /dojo-.*\.js$/,
-				loader: 'source-map-loader'
-			}
-		],
-		loaders: [
-			{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
-			{ test: /\.js?$/, loader: 'umd-compat-loader' },
-			{ test: /\.html$/, loader: 'html' },
-			{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
-			{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
-			{ test: /\.css$/, loader: 'style-loader!css-loader?modules' },
-		]
-	},
-	plugins: [
+module.exports = function (args) {
+	args = args || {};
+
+	let plugins = [
 		new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 		new ExtractTextPlugin('main.css'),
 		new CopyWebpackPlugin([
@@ -52,9 +22,54 @@ module.exports = {
 			chunks: [ 'src/main' ],
 			template: 'src/index.html'
 		})
-	],
-	output: {
-		path: path.resolve('./dist'),
-		filename: '[name].js'
+	];
+
+	if (!args.watch) {
+		plugins.push(new BundleAnalyzerPlugin({
+			analyzerMode: 'static',
+			openAnalyzer: false,
+			reportType: 'sunburst'
+		}));
 	}
-};
+
+	return {
+		entry: {
+			'src/main': [
+				path.join(basePath, 'src/main.styl'),
+				path.join(basePath, 'src/main.ts')
+			]
+		},
+		devtool: 'source-map',
+		resolve: {
+			root: [ basePath ],
+			extensions: ['', '.ts', '.tsx', '.js'],
+			alias: {
+				rxjs: '@reactivex/rxjs/dist/amd'
+			}
+		},
+		resolveLoader: {
+			root: [ path.join(__dirname, 'node_modules') ]
+		},
+		module: {
+			preLoaders: [
+				{
+					test: /dojo-.*\.js$/,
+					loader: 'source-map-loader'
+				}
+			],
+			loaders: [
+				{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
+				{ test: /\.js?$/, loader: 'umd-compat-loader' },
+				{ test: /\.html$/, loader: 'html' },
+				{ test: /\.(jpe|jpg|png|woff|woff2|eot|ttf|svg)(\?.*$|$)/, loader: 'file?name=[path][name].[hash:6].[ext]' },
+				{ test: /\.styl$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', 'stylus-loader']) },
+				{ test: /\.css$/, loader: 'style-loader!css-loader?modules' },
+			]
+		},
+		plugins: plugins,
+		output: {
+			path: path.resolve('./dist'),
+			filename: '[name].js'
+		}
+	};
+}

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -17,7 +17,16 @@ describe('main', () => {
 		mockModule = new MockModule('../../src/main');
 		mockModule.dependencies(['./webpack.config', 'webpack', 'webpack-dev-server']);
 		mockWebpack = mockModule.getMock('webpack');
-		mockWebpackConfig = mockModule.getMock('./webpack.config');
+		const mockWebpackConfigModule = mockModule.getMock('./webpack.config');
+		mockWebpackConfig = {
+			entry: {
+				'src/main': [
+					'src/main.styl',
+					'src/main.ts'
+				]
+			}
+		};
+		mockWebpackConfigModule.ctor.returns(mockWebpackConfig);
 		moduleUnderTest = mockModule.getModuleUnderTest().default;
 		sandbox.stub(console, 'log');
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

![sunburst](https://cloud.githubusercontent.com/assets/334586/20982578/2cf7001e-bc87-11e6-8181-1938f1f9d283.gif)

This PR adds bundle size reporting to production webpack builds by generating a `report.html` file in the `dist` folder. It makes use of [bitpshr/webpack-bundle-analyzer-sunburst](https://github.com/bitpshr/webpack-bundle-analyzer) which was forked from [th0r/webpack-bundle-analyzer](https://github.com/th0r/webpack-bundle-analyzer) and modified to support non-commercial sunbursts charts via a [hand-rolled d3 implementation](https://github.com/bitpshr/webpack-bundle-analyzer/blob/master/client/components/Sunburst.jsx). I manually tested this on a generated Dojo 2 app, TodoMVC, and Monster Cards, and everything seemed fine. I verified that the size of each file on disk equaled the parsed file size in the report. It may be good for @matt-gadd or someone more familiar with webpack to double-check the output for an example project.

We may also want @itorrey to work up a better design, but I don't think this is a blocker. It's slightly annoying that we can't see size information by the cursor when hovering chart segments.

Resolves #27

