### PR TITLE
Implement app-level config loading.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "@types/node": "0.0.3",
     "codecov.io": "0.1.6",
     "dojo-cli": "^2.0.0-alpha.3",
+    "dojo-interfaces": "^2.0.0-alpha.8",
     "dojo-loader": ">=2.0.0-beta.7",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",
-    "grunt-tslint": "^3.0.0",
     "grunt-dojo2": "^2.0.0-beta.18",
+    "grunt-tslint": "^3.0.0",
     "intern": "~3.3.2",
     "istanbul": "^0.4.3",
     "mockery": "^1.7.0",

--- a/src/loadDojoConfig.ts
+++ b/src/loadDojoConfig.ts
@@ -1,0 +1,24 @@
+import * as path from 'path';
+
+export interface DojoConfig {}
+
+/**
+ * Load the Dojo configuration at the specified path (relative to the current working directory).
+ * If no config exists at the specified path, then a default object is returned.
+ *
+ * @param configPath
+ * The path to the config file, relative to the current working directory.
+ *
+ * @return
+ * The configuration module's default export, or a default object.
+ */
+export default function loadDojoConfig(configPath: string): DojoConfig {
+	let config: DojoConfig = Object.create(null);
+
+	try {
+		config = require(path.resolve(process.cwd(), configPath));
+	}
+	catch (error) {}
+
+	return config;
+}

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -1,6 +1,8 @@
+import { RootRequire } from 'dojo-interfaces/loader';
 import * as mockery from 'mockery';
 import * as sinon from 'sinon';
 
+declare const require: RootRequire;
 const dojoNodePlugin = 'intern/dojo/node';
 
 function load(modulePath: string): any {

--- a/tests/support/mocks/dojo.config.js
+++ b/tests/support/mocks/dojo.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	foo: 'foo',
+	bar: 'bar'
+};

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,1 +1,2 @@
+import './loadDojoConfig';
 import './main';

--- a/tests/unit/loadDojoConfig.ts
+++ b/tests/unit/loadDojoConfig.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'intern!bdd';
+import * as assert from 'intern/chai!assert';
+import loadDojoConfig from '../../src/loadDojoConfig';
+
+describe('loadDojoConfig', () => {
+	it('should load the specified module if it exists', () => {
+		const config = loadDojoConfig('tests/support/mocks/dojo.config.js');
+		assert.deepEqual(config, {
+			foo: 'foo',
+			bar: 'bar'
+		});
+	});
+
+	it('should load an empty object if no config exists', () => {
+		const config = loadDojoConfig('path/to/nonexistent/dojo.config.js');
+		assert.deepEqual(config, {}, 'A default config is returned.');
+	});
+});

--- a/typings.json
+++ b/typings.json
@@ -15,10 +15,6 @@
 		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
 		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#8f3dfe6cafd04dfa78068785551552a5cfd88db1",
-		"mockery": "registry:dt/mockery#1.4.0+20160316155526",
-		"node": "github:dojo/typings/custom/node/node.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
-	},
-	"globalDependencies": {
-		"dojo-loader": "npm:dojo-loader"
+		"mockery": "registry:dt/mockery#1.4.0+20160316155526"
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:** Provides the ability to load an application-level configuration object that will eventually be used to pass app-specific data to the build. If there is no config file in the specified location, then a default config is returned. At present the default config is an empty object, and it is not being loaded by the webpack config as there is nothing that currently needs it. Upcoming features like #30 will use the the app config to determine the final build.

Resolves #29 