### PR TITLE
Keep global require's toUrl and toAbsMid methods intact

### DIFF
--- a/src/plugins/CoreLoadPlugin.ts
+++ b/src/plugins/CoreLoadPlugin.ts
@@ -83,7 +83,17 @@ export default class DojoLoadPlugin {
 			compilation.moduleTemplate.plugin('module', (source: any, module: any) => {
 				if (module.meta && module.meta.isPotentialLoad) {
 					const path = stripPath(basePath, module.userRequest);
-					const require = `var require = function () { return '${path}'; };`;
+					const require = `var require = (function () {
+						var globalScope = typeof window === 'undefined' ? global : window;
+						var toUrl = globalScope && globalScope.require && globalScope.require.toUrl
+						&& globalScope.require.toUrl.bind(globalScope.require);
+						var toAbsMid = globalScope && globalScope.require && globalScope.require.toAbsMid
+						&& globalScope.require.toAbsMid.bind(globalScope.require);
+						var newRequire = function () { return '${path}'; }; 
+						newRequire.toUrl = toUrl;
+						newRequire.toAbsMid = toAbsMid;
+						return newRequire;
+					})();`;
 					return new ConcatSource(require, '\n', source);
 				}
 				const load = idMap['@dojo/core/load'] || { id: null };

--- a/src/plugins/CoreLoadPlugin.ts
+++ b/src/plugins/CoreLoadPlugin.ts
@@ -84,11 +84,25 @@ export default class DojoLoadPlugin {
 				if (module.meta && module.meta.isPotentialLoad) {
 					const path = stripPath(basePath, module.userRequest);
 					const require = `var require = (function () {
-						var globalScope = typeof window === 'undefined' ? global : window;
-						var toUrl = globalScope && globalScope.require && globalScope.require.toUrl
-						&& globalScope.require.toUrl.bind(globalScope.require);
-						var toAbsMid = globalScope && globalScope.require && globalScope.require.toAbsMid
-						&& globalScope.require.toAbsMid.bind(globalScope.require);
+						var globalObject = (function () {
+							if (typeof window !== 'undefined') {
+								// Browsers
+								return window;
+							}
+							else if (typeof global !== 'undefined') {
+								// Node
+								return global;
+							}
+							else if (typeof self !== 'undefined') {
+								// Web workers
+								return self;
+							}
+							return {};
+						})();
+						var toUrl = globalObject && globalObject.require && globalObject.require.toUrl
+						&& globalObject.require.toUrl.bind(globalObject.require);
+						var toAbsMid = globalObject && globalObject.require && globalObject.require.toAbsMid
+						&& globalObject.require.toAbsMid.bind(globalObject.require);
 						var newRequire = function () { return '${path}'; }; 
 						newRequire.toUrl = toUrl;
 						newRequire.toAbsMid = toAbsMid;

--- a/src/plugins/CoreLoadPlugin.ts
+++ b/src/plugins/CoreLoadPlugin.ts
@@ -99,9 +99,9 @@ export default class DojoLoadPlugin {
 							}
 							return {};
 						})();
-						var toUrl = globalObject && globalObject.require && globalObject.require.toUrl
+						var toUrl = globalObject.require && globalObject.require.toUrl
 						&& globalObject.require.toUrl.bind(globalObject.require);
-						var toAbsMid = globalObject && globalObject.require && globalObject.require.toAbsMid
+						var toAbsMid = globalObject.require && globalObject.require.toAbsMid
 						&& globalObject.require.toAbsMid.bind(globalObject.require);
 						var newRequire = function () { return '${path}'; }; 
 						newRequire.toUrl = toUrl;

--- a/tests/unit/plugins/CoreLoadPlugin.ts
+++ b/tests/unit/plugins/CoreLoadPlugin.ts
@@ -78,9 +78,9 @@ describe('core-load', () => {
 							}
 							return {};
 						})();
-						var toUrl = globalObject && globalObject.require && globalObject.require.toUrl
+						var toUrl = globalObject.require && globalObject.require.toUrl
 						&& globalObject.require.toUrl.bind(globalObject.require);
-						var toAbsMid = globalObject && globalObject.require && globalObject.require.toAbsMid
+						var toAbsMid = globalObject.require && globalObject.require.toAbsMid
 						&& globalObject.require.toAbsMid.bind(globalObject.require);
 						var newRequire = function () { return '/root/path/src/module'; }; 
 						newRequire.toUrl = toUrl;

--- a/tests/unit/plugins/CoreLoadPlugin.ts
+++ b/tests/unit/plugins/CoreLoadPlugin.ts
@@ -62,7 +62,17 @@ describe('core-load', () => {
 		})[0];
 
 		assert.instanceOf(source, ConcatSource, 'A new `ConcatSource` is created.');
-		assert.strictEqual(source.source(), `var require = function () { return '/root/path/src/module'; };\n`,
+		assert.strictEqual(source.source(), `var require = (function () {
+						var globalScope = typeof window === 'undefined' ? global : window;
+						var toUrl = globalScope && globalScope.require && globalScope.require.toUrl
+						&& globalScope.require.toUrl.bind(globalScope.require);
+						var toAbsMid = globalScope && globalScope.require && globalScope.require.toAbsMid
+						&& globalScope.require.toAbsMid.bind(globalScope.require);
+						var newRequire = function () { return '/root/path/src/module'; }; 
+						newRequire.toUrl = toUrl;
+						newRequire.toAbsMid = toAbsMid;
+						return newRequire;
+					})();\n`,
 			'A custom `require` function is injected into the source.');
 	});
 

--- a/tests/unit/plugins/CoreLoadPlugin.ts
+++ b/tests/unit/plugins/CoreLoadPlugin.ts
@@ -63,11 +63,25 @@ describe('core-load', () => {
 
 		assert.instanceOf(source, ConcatSource, 'A new `ConcatSource` is created.');
 		assert.strictEqual(source.source(), `var require = (function () {
-						var globalScope = typeof window === 'undefined' ? global : window;
-						var toUrl = globalScope && globalScope.require && globalScope.require.toUrl
-						&& globalScope.require.toUrl.bind(globalScope.require);
-						var toAbsMid = globalScope && globalScope.require && globalScope.require.toAbsMid
-						&& globalScope.require.toAbsMid.bind(globalScope.require);
+						var globalObject = (function () {
+							if (typeof window !== 'undefined') {
+								// Browsers
+								return window;
+							}
+							else if (typeof global !== 'undefined') {
+								// Node
+								return global;
+							}
+							else if (typeof self !== 'undefined') {
+								// Web workers
+								return self;
+							}
+							return {};
+						})();
+						var toUrl = globalObject && globalObject.require && globalObject.require.toUrl
+						&& globalObject.require.toUrl.bind(globalObject.require);
+						var toAbsMid = globalObject && globalObject.require && globalObject.require.toAbsMid
+						&& globalObject.require.toAbsMid.bind(globalObject.require);
 						var newRequire = function () { return '/root/path/src/module'; }; 
 						newRequire.toUrl = toUrl;
 						newRequire.toAbsMid = toAbsMid;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Currently, if code is calling `require.toUrl`, that will trigger the `expression require` condition and that module will have `require = function() { return '${path}'; }` prepended to it. However, this function obviously doesn't have a `toUrl` property so the call will fail. Checking for usages of `require.toUrl` and not replacing require at all is problematic because webpack will still replace it with `__webpack_require__` which doesn't have a `toUrl` function either.

It seems like there should probably be a better way to handle this. But this does work for todoMVC at least.