### PR TITLE
Removed tsx and rxjs refs from webpack config

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -93,10 +93,7 @@ module.exports = function (args) {
 		devtool: 'source-map',
 		resolve: {
 			root: [ basePath ],
-			extensions: ['', '.ts', '.tsx', '.js', '.css.json'],
-			alias: {
-				rxjs: '@reactivex/rxjs/dist/amd'
-			}
+			extensions: ['', '.ts', '.js', '.css.json']
 		},
 		resolveLoader: {
 			root: [ path.join(__dirname, 'node_modules') ]


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

Resolves #49 
