### PR TITLE
CSS module loading in umd format

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = function (args) {
 		devtool: 'source-map',
 		resolve: {
 			root: [ basePath ],
-			extensions: ['', '.ts', '.js', '.css.json']
+			extensions: ['', '.ts', '.js']
 		},
 		resolveLoader: {
 			root: [ path.join(__dirname, 'node_modules') ]
@@ -109,7 +109,7 @@ module.exports = function (args) {
 				{ test: /\.html$/, loader: 'html' },
 				{ test: /src[\\\/].*\.css?$/, loader: cssModuleLoader },
 				{ test: /\.css$/, exclude: /src[\\\/].*/, loader: cssLoader },
-				{ test: /\.css\.json$/, exclude: /src[\\\/].*/, loader: 'json-css-module-loader' }
+				{ test: /styles\/.*\.js$/, exclude: /src[\\\/].*/, loader: 'json-css-module-loader' }
 			]
 		}
 	};

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -93,10 +93,7 @@ module.exports = function (args) {
 		devtool: 'source-map',
 		resolve: {
 			root: [ basePath ],
-			extensions: ['', '.ts', '.tsx', '.js', '.css.json'],
-			alias: {
-				rxjs: '@reactivex/rxjs/dist/amd'
-			}
+			extensions: ['', '.ts', '.js', '.css.json']
 		},
 		resolveLoader: {
 			root: [ path.join(__dirname, 'node_modules') ]


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Revised css-module process will now output a UMD format `.js` file rather than a `json` file.
`json-css-module-loader` still needs a release / tests before this code will work correctly.

Resolves https://github.com/dojo/widgets/issues/272
