### PR TITLE
Adding options to build components

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,7 @@
 module.exports = function (grunt) {
-	require('grunt-dojo2').initConfig(grunt, {});
+    require('grunt-dojo2').initConfig(grunt, {
+        staticDefinitionFiles: ['**/*.d.ts', '**/*.html']
+    });
 	grunt.registerTask('ci', [
 		'intern:node'
 	]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,8 @@
-module.exports = function (grunt) {
+module.exports = function(grunt) {
     require('grunt-dojo2').initConfig(grunt, {
         staticDefinitionFiles: ['**/*.d.ts', '**/*.html']
     });
-	grunt.registerTask('ci', [
-		'intern:node'
-	]);
+    grunt.registerTask('ci', [
+        'intern:node'
+    ]);
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt": "~1.0.1",
     "grunt-dojo2": "^2.0.0-beta.18",
     "grunt-tslint": "^3.0.0",
+    "imports-loader": "^0.6.5",
     "intern": "^3.4.1",
     "istanbul": "^0.4.3",
     "mockery": "^1.7.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ interface BuildArgs extends Argv {
 	supportedLocales: string | string[];
 	watch: boolean;
 	port: number;
+	element: string;
+	elementPrefix: string;
 }
 
 interface WebpackOptions {
@@ -35,6 +37,18 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 
 	if (supportedLocales) {
 		options.supportedLocales = Array.isArray(supportedLocales) ? supportedLocales : [ supportedLocales ];
+	}
+
+	if (args.element && !args.elementPrefix) {
+		const factoryPattern = /create(.*?)Element.*?\.ts$/;
+		const matches = args.element.match(factoryPattern);
+
+		if (matches && matches[ 1 ]) {
+			options.elementPrefix = matches[ 1 ].replace(/[A-Z][a-z]/g, '-\$&').replace(/^-+/g, '').toLowerCase();
+		} else {
+			console.error(`"${args.element}" does not follow the pattern "createXYZElement". Use --elementPrefix to name element.`);
+			process.exit();
+		}
 	}
 
 	return options;

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,6 +109,16 @@ const command: Command = {
 			type: 'array'
 		});
 
+		helper.yargs.option('element', {
+			describe: 'Path to a custom element descriptor factory',
+			type: 'string'
+		});
+
+		helper.yargs.option('elementPrefix', {
+			describe: 'Output file for custom element',
+			type: 'string'
+		});
+
 		return helper.yargs;
 	},
 	run(helper: Helper, args: BuildArgs) {

--- a/src/templates/custom-element.html
+++ b/src/templates/custom-element.html
@@ -1,0 +1,6 @@
+<% for (var css in htmlWebpackPlugin.files.css) { %>
+<link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+<% } %>
+<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
+<script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+<% } %>

--- a/src/templates/custom-element.ts
+++ b/src/templates/custom-element.ts
@@ -1,0 +1,5 @@
+const registerCustomElement: any = require('@dojo/widget-core/registerCustomElement').default;
+
+declare const widgetFactory: any;
+
+registerCustomElement(widgetFactory.default);

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -26,8 +26,8 @@ module.exports = function (args: any) {
 
 	const replacedModules = new Set<string>();
 
-	function includeWhen(predicate: boolean, callback: any) {
-		return predicate ? callback(args) : [];
+	function includeWhen(predicate: boolean, callback: any, elseCallback: any = null) {
+		return predicate ? callback(args) : (elseCallback ? elseCallback(args) : []);
 	}
 
 	return {
@@ -39,22 +39,29 @@ module.exports = function (args: any) {
 				callback();
 			}
 		],
-		entry: {
-			'src/main': [
-				path.join(basePath, 'src/main.css'),
-				path.join(basePath, 'src/main.ts')
-			],
-			...includeWhen(args.withTests, (args: any) => {
-				return {
-					'../_build/tests/unit/all': [ path.join(basePath, 'tests/unit/all.ts') ],
-					'../_build/tests/functional/all': [ path.join(basePath, 'tests/functional/all.ts') ],
-					'../_build/src/main': [
-						path.join(basePath, 'src/main.css'),
-						path.join(basePath, 'src/main.ts')
-					]
-				};
-			})
-		},
+		entry: includeWhen(args.c, (args: any) => {
+			return {
+				[args.elementPrefix]: [ `${__dirname}/templates/custom-element.js` ],
+				'widget-core': '@dojo/widget-core'
+			};
+		}, (args: any) => {
+			return {
+				'src/main': [
+					path.join(basePath, 'src/main.css'),
+					path.join(basePath, 'src/main.ts')
+				],
+				...includeWhen(args.withTests, (args: any) => {
+					return {
+						'../_build/tests/unit/all': [ path.join(basePath, 'tests/unit/all.ts') ],
+						'../_build/tests/functional/all': [ path.join(basePath, 'tests/functional/all.ts') ],
+						'../_build/src/main': [
+							path.join(basePath, 'src/main.css'),
+							path.join(basePath, 'src/main.ts')
+						]
+					};
+				})
+			};
+		}),
 		plugins: [
 			new NormalModuleReplacementPlugin(/\.css$/, (result: any) => {
 				const requestFileName = path.resolve(result.context, result.request);
@@ -68,21 +75,42 @@ module.exports = function (args: any) {
 				}
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
-			new ExtractTextPlugin('main.css'),
-			new CopyWebpackPlugin([
-				{ context: 'src', from: '**/*', ignore: '*.ts' }
-			]),
+			includeWhen(args.element, (args: any) => {
+				return new ExtractTextPlugin(`${args.elementPrefix}.css`);
+			}, (args: any) => {
+				return new ExtractTextPlugin('main.css');
+			}),
+			includeWhen(args.element, (args: any) => {
+				return new CopyWebpackPlugin([
+					{ context: 'src', from: '**/*', ignore: [ '*.ts', '*.css', '*.html' ] }
+				]);
+			}, (args: any) => {
+				return new CopyWebpackPlugin([
+					{ context: 'src', from: '**/*', ignore: '*.ts' }
+				]);
+			}),
 			new webpack.optimize.DedupePlugin(),
 			new InjectModulesPlugin({
 				resourcePattern: /dojo-core\/request(\.js)?$/,
 				moduleIds: [ './request/xhr' ]
 			}),
 			new CoreLoadPlugin(),
+			...includeWhen(args.element, (args: any) => {
+				return [ new webpack.optimize.CommonsChunkPlugin('widget-core', 'widget-core.js') ];
+			}),
 			new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false }, exclude: /tests[/]/ }),
-			new HtmlWebpackPlugin ({
-				inject: true,
-				chunks: [ 'src/main' ],
-				template: 'src/index.html'
+			includeWhen(args.element, (args: any) => {
+				return new HtmlWebpackPlugin({
+					inject: false,
+					template: path.join(__dirname, 'templates/custom-element.html'),
+					filename: `${args.elementPrefix}.html`
+				});
+			}, (args: any) => {
+				return new HtmlWebpackPlugin({
+					inject: true,
+					chunks: [ 'src/main' ],
+					template: 'src/index.html'
+				});
 			}),
 			...includeWhen(args.locale, (args: any) => {
 				return [
@@ -133,7 +161,7 @@ module.exports = function (args: any) {
 		},
 		devtool: 'source-map',
 		resolve: {
-			root: [ basePath ],
+			root: [ basePath, path.join(basePath, 'node_modules') ],
 			extensions: ['', '.ts', '.js']
 		},
 		resolveLoader: {
@@ -150,13 +178,23 @@ module.exports = function (args: any) {
 				{ test: /src[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' },
 				{ test: /\.js?$/, loader: 'umd-compat-loader' },
 				{ test: /globalize(\/|$)/, loader: 'imports-loader?define=>false' },
-				{ test: /\.html$/, loader: 'html' },
+				...includeWhen(!args.element, (args: any) => {
+					return [ { test: /\.html$/, loader: 'html' } ];
+				}),
 				{ test: /\.css$/, exclude: /src[\\\/].*/, loader: cssLoader },
 				{ test: /src[\\\/].*\.css?$/, loader: cssModuleLoader },
 				{ test: /\.css.js$/, exclude: /src[\\\/].*/, loaders: ['json-css-module-loader'] },
 				...includeWhen(args.withTests, (args: any) => {
 					return [
 						{ test: /tests[\\\/].*\.ts?$/, loader: 'umd-compat-loader!ts-loader' }
+					];
+				}),
+				...includeWhen(args.element, (args: any) => {
+					return [
+						{
+							test: /custom-element\.js/,
+							loader: `imports-loader?widgetFactory=${args.element}`
+						}
 					];
 				})
 			]

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -39,7 +39,7 @@ module.exports = function (args: any) {
 				callback();
 			}
 		],
-		entry: includeWhen(args.c, (args: any) => {
+		entry: includeWhen(args.element, (args: any) => {
 			return {
 				[args.elementPrefix]: [ `${__dirname}/templates/custom-element.js` ],
 				'widget-core': '@dojo/widget-core'
@@ -156,7 +156,11 @@ module.exports = function (args: any) {
 		],
 		output: {
 			libraryTarget: 'umd',
-			path: path.resolve('./dist'),
+			path: includeWhen(args.element, (args: any) => {
+				return path.resolve(`./dist/${args.elementPrefix}`);
+			}, () => {
+				return path.resolve('./dist');
+			}),
 			filename: '[name].js'
 		},
 		devtool: 'source-map',

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -62,4 +62,4 @@ export const loaderOptions = {
 export const suites = [ 'tests/unit/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]|webpack\.config/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]|webpack\.config|templates/;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding additional options to generate custom element packages and imports. 

Usage:

```bash
$ dojo build --element=src/widget/createMyWidgetElementDescriptor
```

This will bundle all of the dependencies from `createMyWidgetElementDescriptor` (usually your widget) and create the files,

* `dist/my-widget/my-widget.js` - JS for your widget
* `dist/my-widget/widget-core.js` - JS for widget core
* `dist/my-widget/my-widget.css` - CSS for your widget
* `dist/my-widget/my-widget.html` - HTML import containing all your widget dependencies

There is an optional parameter to name the output files, `--elementPrefix`, that you can specify if your input file does not follow the convention `createXYZElement`.

To use in an HTML file,

```html
<head>
    <script src="https://rawgit.com/webcomponents/custom-elements/master/src/native-shim.js"></script>
    <link rel="import" href="/path/to/myWidget.html">
</head>
<body>
    <my-widget></my-widget>
</body>
```