### PR TITLE
Add local node_nodules resolution to fix grunt link

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -177,7 +177,7 @@ module.exports = function (args: any) {
 			extensions: ['.ts', '.js']
 		},
 		resolveLoader: {
-			modules: [ path.join(__dirname, 'loaders'), 'node_modules' ]
+			modules: [ path.join(__dirname, 'loaders'), path.join(__dirname, 'node_modules'), 'node_modules' ]
 		},
 		module: {
 			rules: [


### PR DESCRIPTION
**Type:** bug

**Description:**
Currently it's not possible to `grunt link` this project due to some behaviour we depend on in dts-loader. Turns out this did actually work fine pre webpack 2 conversion https://github.com/dojo/cli-build/pull/67, because we actually had the local node_modules in our resolving paths (https://github.com/dojo/cli-build/blob/b727d5256816db14d6c39421da6912d2c3fc7ea6/src/webpack.config.ts#L173)

