### PR TITLE
Fixing widget-core split, adding profile option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { Command, Helper, OptionsHelper } from '@dojo/cli/interfaces';
 import { Argv } from 'yargs';
+import config from './webpack.config';
+import * as fs from 'fs';
 import webpack = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');
-import config from './webpack.config';
 
 export interface BuildArgs extends Argv {
 	locale: string;
@@ -13,6 +14,7 @@ export interface BuildArgs extends Argv {
 	element: string;
 	elementPrefix: string;
 	withTests: boolean;
+	profile: boolean;
 }
 
 interface WebpackOptions {
@@ -98,6 +100,10 @@ function compile(config: webpack.Config, options: WebpackOptions): Promise<any> 
 			}
 
 			if (stats) {
+				if (config.profile) {
+					fs.writeFileSync('dist/profile.json', JSON.stringify(stats.toJson()));
+				}
+
 				console.log(stats.toString(options.stats));
 			}
 			resolve({});
@@ -147,6 +153,11 @@ const command: Command = {
 		options('elementPrefix', {
 			describe: 'Output file for custom element',
 			type: 'string'
+		});
+
+		options('profile', {
+			describe: 'Generate webpack profiling information',
+			type: 'boolean'
 		});
 	},
 	run(helper: Helper, args: BuildArgs) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ export interface BuildArgs extends Argv {
 	element: string;
 	elementPrefix: string;
 	withTests: boolean;
-	profile: boolean;
+	debug: boolean;
 }
 
 interface WebpackOptions {
@@ -155,8 +155,8 @@ const command: Command = {
 			type: 'string'
 		});
 
-		options('profile', {
-			describe: 'Generate webpack profiling information',
+		options('debug', {
+			describe: 'Generate package information useful for debugging',
 			type: 'boolean'
 		});
 	},

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -235,7 +235,7 @@ export default function webpackConfig(args: Partial<BuildArgs>) {
 		}
 	};
 
-	if (args.profile) {
+	if (args.debug) {
 		config.profile = true;
 	}
 

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -2,6 +2,9 @@ import webpack = require('webpack');
 import NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
 import * as path from 'path';
 import { existsSync } from 'fs';
+import CoreLoadPlugin from './plugins/CoreLoadPlugin';
+import I18nPlugin from './plugins/I18nPlugin';
+import { BuildArgs } from './main';
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -9,13 +12,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer-sunburst').BundleA
 const postcssImport = require('postcss-import');
 const postcssCssNext = require('postcss-cssnext');
 
-import CoreLoadPlugin from './plugins/CoreLoadPlugin';
-import I18nPlugin from './plugins/I18nPlugin';
-import InjectModulesPlugin from './plugins/InjectModulesPlugin';
-
 const basePath = process.cwd();
-
-import { BuildArgs } from './main';
 
 type IncludeCallback = (args: BuildArgs) => any;
 
@@ -58,12 +55,17 @@ export default function webpackConfig(args: Partial<BuildArgs>) {
 				if (/^intern[!\/]/.test(request)) {
 					return callback(null, 'amd ' + request);
 				}
+
+				if (/request\/providers\/node/.test(request)) {
+					return callback(null, 'amd ' + request);
+				}
+
 				callback();
 			}
 		],
 		entry: includeWhen(args.element, args => {
 			return {
-				[args.elementPrefix]: [ `${__dirname}/templates/custom-element.js` ],
+				[args.elementPrefix]: `${__dirname}/templates/custom-element.js`,
 				'widget-core': '@dojo/widget-core'
 			};
 		}, args => {
@@ -111,13 +113,12 @@ export default function webpackConfig(args: Partial<BuildArgs>) {
 					{ context: 'src', from: '**/*', ignore: '*.ts' }
 				]);
 			}),
-			new InjectModulesPlugin({
-				resourcePattern: /dojo-core\/request(\.js)?$/,
-				moduleIds: [ './request/xhr' ]
-			}),
 			new CoreLoadPlugin(),
 			...includeWhen(args.element, () => {
-				return [ new webpack.optimize.CommonsChunkPlugin({ name: 'widget-core', filename: 'widget-core.js' }) ];
+				return [ new webpack.optimize.CommonsChunkPlugin({
+					name: 'widget-core',
+					filename: 'widget-core.js'
+				}) ];
 			}),
 			new webpack.optimize.UglifyJsPlugin({ sourceMap: true, compress: { warnings: false }, exclude: /tests[/]/ }),
 			includeWhen(args.element, args => {
@@ -233,6 +234,10 @@ export default function webpackConfig(args: Partial<BuildArgs>) {
 			]
 		}
 	};
+
+	if (args.profile) {
+		config.profile = true;
+	}
 
 	return config;
 }

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -112,6 +112,7 @@ declare module 'webpack/lib/webpack' {
 			externals?: { [key: string]: string | string[] | Object } | ((context: string, request: string, callback: Function) => void)[];
 			stats?: Stats;
 			plugins?: Plugin[];
+			profile?: boolean;
 		}
 		type DevtoolFilenameTemplateFunction = (info: DevtoolFilenameTemplateInfo) => string;
 		interface DevtoolFilenameTemplateInfo {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -77,7 +77,7 @@ describe('main', () => {
 
 		assert.deepEqual(
 			options.args[ 8 ],
-			[ 'profile', { describe: 'Generate webpack profiling information', type: 'boolean' } ]
+			[ 'debug', { describe: 'Generate package information useful for debugging', type: 'boolean' } ]
 		);
 	});
 
@@ -173,7 +173,7 @@ describe('main', () => {
 		});
 	});
 
-	describe('profile options', () => {
+	describe('debug options', () => {
 		beforeEach(() => {
 			mockWebpack.returns({
 				run: sandbox.stub().yields(null, {
@@ -186,10 +186,10 @@ describe('main', () => {
 
 		it('should pass the profile option to webpack', () => {
 			return moduleUnderTest.run({}, {
-				profile: true
+				debug: true
 			}).then(() => {
 				assert.isTrue(mockWebpackConfigModule.calledWith({
-					profile: true
+					debug: true
 				}), JSON.stringify(mockWebpack.args));
 			});
 		});
@@ -208,7 +208,7 @@ describe('main', () => {
 			});
 
 			return moduleUnderTest.run(null, {
-				profile: true
+				debug: true
 			}).then(() => {
 				assert.isTrue(fsMock.called);
 				assert.strictEqual(fsMock.getCall(0).args[ 0 ], 'dist/profile.json');

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,8 +1,9 @@
-import { beforeEach, afterEach, describe, it } from 'intern!bdd';
+import { afterEach, beforeEach, describe, it } from 'intern!bdd';
 import * as assert from 'intern/chai!assert';
 import MockModule from '../support/MockModule';
 import { throwImmediately } from '../support/util';
 import * as sinon from 'sinon';
+import * as fs from 'fs';
 
 describe('main', () => {
 
@@ -30,6 +31,7 @@ describe('main', () => {
 		mockWebpackConfigModule.returns(mockWebpackConfig);
 		moduleUnderTest = mockModule.getModuleUnderTest().default;
 		sandbox.stub(console, 'log');
+		sandbox.stub(console, 'error');
 	});
 
 	afterEach(() => {
@@ -72,6 +74,11 @@ describe('main', () => {
 			options.args[7],
 			[ 'elementPrefix', { describe: 'Output file for custom element', type: 'string' }]
 		);
+
+		assert.deepEqual(
+			options.args[ 8 ],
+			[ 'profile', { describe: 'Generate webpack profiling information', type: 'boolean' } ]
+		);
 	});
 
 	it('should run compile and log results on success', () => {
@@ -80,6 +87,15 @@ describe('main', () => {
 		return moduleUnderTest.run({}, {}).then(() => {
 			assert.isTrue(run.calledOnce);
 			assert.isTrue((<sinon.SinonStub> console.log).calledWith('some stats'));
+		});
+	});
+
+	it('should not print stats if they aren\'t there', () => {
+		const run = sandbox.stub().yields(false, null);
+		mockWebpack.returns({ run });
+		return moduleUnderTest.run({}, {}).then(() => {
+			assert.isTrue(run.calledOnce);
+			assert.isFalse((<sinon.SinonStub> console.log).called);
 		});
 	});
 
@@ -153,6 +169,84 @@ describe('main', () => {
 					supportedLocales: [ 'fr' ],
 					messageBundles: [ 'nls/main' ]
 				}), JSON.stringify(mockWebpack.args));
+			});
+		});
+	});
+
+	describe('profile options', () => {
+		beforeEach(() => {
+			mockWebpack.returns({
+				run: sandbox.stub().yields(null, {
+					toJson() {
+						return 'test json';
+					}
+				})
+			});
+		});
+
+		it('should pass the profile option to webpack', () => {
+			return moduleUnderTest.run({}, {
+				profile: true
+			}).then(() => {
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					profile: true
+				}), JSON.stringify(mockWebpack.args));
+			});
+		});
+
+		it('should create profile json file', () => {
+			const fsMock = sandbox.stub(fs, 'writeFileSync');
+
+			mockWebpackConfigModule.returns({
+				entry: {
+					'src/main': [
+						'src/main.styl',
+						'src/main.ts'
+					]
+				},
+				profile: true
+			});
+
+			return moduleUnderTest.run(null, {
+				profile: true
+			}).then(() => {
+				assert.isTrue(fsMock.called);
+				assert.strictEqual(fsMock.getCall(0).args[ 0 ], 'dist/profile.json');
+				assert.strictEqual(fsMock.getCall(0).args[ 1 ], '"test json"');
+
+				fsMock.restore();
+			});
+		});
+	});
+
+	describe('custom element options', () => {
+		beforeEach(() => {
+			mockWebpack.returns({
+				run: sandbox.stub().yields(null, 'stats')
+			});
+		});
+
+		it('should set the element prefix if it matches the pattern', () => {
+			return moduleUnderTest.run({}, {
+				'element': '/path/to/createTestElement.ts'
+			}).then(() => {
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					element: '/path/to/createTestElement.ts',
+					elementPrefix: 'test'
+				}), JSON.stringify(mockWebpackConfigModule.args));
+			});
+		});
+
+		it('should error if the element prefix does not match the pattern', () => {
+			const exitMock = sandbox.stub(process, 'exit');
+
+			return moduleUnderTest.run({}, {
+				'element': '/path/to/myelement.ts'
+			}).then(() => {
+				assert.isTrue(exitMock.called);
+				assert.isTrue((<sinon.SinonStub> console.error).calledWith('"/path/to/myelement.ts" does not follow the pattern "createXYZElement". Use --elementPrefix to name element.'));
+
+				exitMock.restore();
 			});
 		});
 	});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes custom element generation from cli-build.

Also,

* Cleaned up some dead code around `dojo-core/request`
* Added `--profile` option for creating the `.json` file you can upload to webpack's analyzer
* Ignoring `@dojo/core/request/providers/node` because that probably shouldn't be bundled for the browser (plus its hugemongus)
* Added some missing tests around custom element configuration

Note: The `InjectModulesPlugin` appears to be unused now, so we might be able to just delete it.