### PR TITLE
Adding manual bundling from .dojorc, issue #90

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@dojo/has": "2.0.0-alpha.8",
     "@dojo/i18n": "2.0.0-alpha.7",
     "@dojo/shim": "2.0.0-beta.10",
+    "bundle-loader": "^0.5.5",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
@@ -68,10 +69,10 @@
     "style-loader": "^0.13.1",
     "ts-loader": "^2.0.0",
     "typed-css-modules": "^0.2.0",
+    "typescript": "~2.2.1",
     "umd-compat-loader": "^2.0.1",
     "webpack": "^2.2.1",
     "webpack-bundle-analyzer-sunburst": "^1.2.0",
-    "webpack-dev-server": "^2.3.0",
-    "typescript": "~2.2.1"
+    "webpack-dev-server": "^2.3.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,15 @@ import { Command, EjectOutput, Helper, OptionsHelper } from '@dojo/cli/interface
 import { Argv } from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
-import webpack = require('webpack');
 import { underline } from 'chalk';
+import webpack = require('webpack');
 const WebpackDevServer: any = require('webpack-dev-server');
 const config: ConfigFactory = require('./webpack.config');
 const pkgDir = require('pkg-dir');
+
+export interface Bundles {
+	[key: string]: string[];
+}
 
 export interface BuildArgs extends Argv {
 	locale: string;
@@ -18,6 +22,7 @@ export interface BuildArgs extends Argv {
 	elementPrefix: string;
 	withTests: boolean;
 	debug: boolean;
+	bundles: Bundles;
 }
 
 interface ConfigFactory {

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -179,7 +179,8 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			}, () => {
 				return path.resolve('./dist');
 			}),
-			filename: '[name].js'
+			filename: '[name].js',
+			chunkFilename: '[name].js'
 		},
 		devtool: 'source-map',
 		resolve: {
@@ -237,6 +238,25 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					return [
 						{ test: /custom-element\.js/, loader: `imports-loader?widgetFactory=${args.element}` }
 					];
+				}),
+				...includeWhen(args.bundles && Object.keys(args.bundles).length, () => {
+					const loaders: any[] = [];
+
+					Object.keys(args.bundles).forEach(bundleName => {
+						(args.bundles || {})[ bundleName ].forEach(fileName => {
+							loaders.push({
+								test: /main\.ts/,
+								loader: {
+									loader: 'imports-loader',
+									options: {
+										'__manual_bundle__': `bundle-loader?lazy&name=${bundleName}!${fileName}`
+									}
+								}
+							});
+						});
+					});
+
+					return loaders;
 				})
 			]
 		}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Manual lazy loading bundling using `.dojorc`.  `.dojorc` looks like this:

```json
{
	"build-webpack": {
		"bundles": {
			"widgets": [
				"src/widgets/TodoFooter",
				"src/widgets/ViewChooser",
				"src/widgets/TodoFilter"
			]
		}
	}
}
```

This will create a `widgets.js` file containing `TodoFooter`, `ViewChooser`, and `TodoFilter`.

Resolves #90 
