### PR TITLE
Webpack config and I18nPlugin fixes.

### DIFF
--- a/src/plugins/I18nPlugin.ts
+++ b/src/plugins/I18nPlugin.ts
@@ -247,7 +247,6 @@ export default class DojoI18nPlugin {
 							return deepAssign(cldrData, source);
 						}, Object.create(null));
 
-					astMap.clear();
 					return new ConcatSource(`var __cldrData__ = ${JSON.stringify(cldrData)}`, '\n', source);
 				}
 

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -61,6 +61,11 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				}
 
 				if (/request\/providers\/node/.test(request)) {
+					if (/^\./.test(request)) {
+						request = /@dojo\/core/.test(context) ?
+							'@dojo/core/request/providers/node' :
+							path.resolve(context, request);
+					}
 					return callback(null, 'amd ' + request);
 				}
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixes a couple bugs uncovered while running `$ dojo test` that went uncaught with just `$ dojo build`.

- Output a resolvable mid for `@dojo/core/request/providers/node` in the `externals` webpack configuration option.
- Fix issue in the I18nPlugin in which the ast map is prematurely cleared in certain cases.
