### PR TITLE
Processing `.m.css` instead of `.css`

### DIFF
--- a/src/loaders/css-module-decorator-loader/loader.ts
+++ b/src/loaders/css-module-decorator-loader/loader.ts
@@ -10,7 +10,7 @@ export default function (this: webpack.LoaderContext, content: string, map?: any
 	if (matches && matches.length > 0) {
 		const localExports = JSON.parse(matches[1]);
 		const themeKey = ' _key';
-		const key = basename(this.resourcePath, '.css');
+		const key = basename(this.resourcePath, '.m.css');
 		localExports[themeKey] = key;
 
 		response = content.replace(localsRexExp, `exports.locals = ${JSON.stringify(localExports)};`);

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -111,7 +111,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			};
 		}),
 		plugins: [
-			new NormalModuleReplacementPlugin(/\.css$/, result => {
+			new NormalModuleReplacementPlugin(/\.m.css$/, result => {
 				const requestFileName = path.resolve(result.context, result.request);
 				const jsFileName = requestFileName + '.js';
 
@@ -119,7 +119,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					replacedModules.delete(requestFileName);
 				} else if (existsSync(jsFileName)) {
 					replacedModules.add(requestFileName);
-					result.request = result.request.replace(/\\.m\.css$/, '.css.js');
+					result.request = result.request.replace(/\.m\.css$/, '.css.js');
 				}
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -95,7 +95,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		}, args => {
 			return {
 				'src/main': [
-					path.join(basePath, 'src/main.css'),
+					path.join(basePath, 'src/main.m.css'),
 					path.join(basePath, 'src/main.ts')
 				],
 				...includeWhen(args.withTests, () => {
@@ -103,7 +103,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						'../_build/tests/unit/all': [ path.join(basePath, 'tests/unit/all.ts') ],
 						'../_build/tests/functional/all': [ path.join(basePath, 'tests/functional/all.ts') ],
 						'../_build/src/main': [
-							path.join(basePath, 'src/main.css'),
+							path.join(basePath, 'src/main.m.css'),
 							path.join(basePath, 'src/main.ts')
 						]
 					};
@@ -119,7 +119,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					replacedModules.delete(requestFileName);
 				} else if (existsSync(jsFileName)) {
 					replacedModules.add(requestFileName);
-					result.request = result.request.replace(/\.css$/, '.css.js');
+					result.request = result.request.replace(/\\.m\.css$/, '.css.js');
 				}
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
@@ -130,7 +130,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			}),
 			includeWhen(args.element, () => {
 				return new CopyWebpackPlugin([
-					{ context: 'src', from: '**/*', ignore: [ '*.ts', '*.css', '*.html' ] }
+					{ context: 'src', from: '**/*', ignore: [ '*.ts', '*.m.css', '*.html' ] }
 				]);
 			}, () => {
 				return new CopyWebpackPlugin([
@@ -236,7 +236,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				}),
 				{ test: /@dojo\/.*\.js$/, enforce: 'pre', loader: 'source-map-loader', options: { includeModulePaths: true } },
 				{ test: /src[\\\/].*\.ts?$/, enforce: 'pre', loader: 'css-module-dts-loader?type=ts&instanceName=0_dojo' },
-				{ test: /src[\\\/].*\.css?$/, enforce: 'pre', loader: 'css-module-dts-loader?type=css' },
+				{ test: /src[\\\/].*\.m\.css?$/, enforce: 'pre', loader: 'css-module-dts-loader?type=css' },
 				{ test: /src[\\\/].*\.ts?$/, use: [
 					'umd-compat-loader',
 					{

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -95,7 +95,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		}, args => {
 			return {
 				'src/main': [
-					path.join(basePath, 'src/main.m.css'),
+					path.join(basePath, 'src/main.css'),
 					path.join(basePath, 'src/main.ts')
 				],
 				...includeWhen(args.withTests, () => {
@@ -103,7 +103,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						'../_build/tests/unit/all': [ path.join(basePath, 'tests/unit/all.ts') ],
 						'../_build/tests/functional/all': [ path.join(basePath, 'tests/functional/all.ts') ],
 						'../_build/src/main': [
-							path.join(basePath, 'src/main.m.css'),
+							path.join(basePath, 'src/main.css'),
 							path.join(basePath, 'src/main.ts')
 						]
 					};
@@ -130,7 +130,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			}),
 			includeWhen(args.element, () => {
 				return new CopyWebpackPlugin([
-					{ context: 'src', from: '**/*', ignore: [ '*.ts', '*.m.css', '*.html' ] }
+					{ context: 'src', from: '**/*', ignore: [ '*.ts', '*.css', '*.html' ] }
 				]);
 			}, () => {
 				return new CopyWebpackPlugin([

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -119,7 +119,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					replacedModules.delete(requestFileName);
 				} else if (existsSync(jsFileName)) {
 					replacedModules.add(requestFileName);
-					result.request = result.request.replace(/\.m\.css$/, '.css.js');
+					result.request = result.request.replace(/\.m\.css$/, '.m.css.js');
 				}
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
@@ -256,7 +256,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				{ test: /.*\.(gif|png|jpe?g|svg)$/i, loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]' },
 				{ test: /\.css$/, exclude: /src[\\\/].*/, loader: cssLoader },
 				{ test: /src[\\\/].*\.css?$/, loader: cssModuleLoader },
-				{ test: /\.css.js$/, exclude: /src[\\\/].*/, use: ['json-css-module-loader'] },
+				{ test: /\.m\.css.js$/, exclude: /src[\\\/].*/, use: ['json-css-module-loader'] },
 				...includeWhen(args.withTests, () => {
 					return [
 						{ test: /tests[\\\/].*\.ts?$/, use: [

--- a/tests/unit/loaders/css-module-decorator-loader.ts
+++ b/tests/unit/loaders/css-module-decorator-loader.ts
@@ -14,7 +14,7 @@ describe('css-module-decorator-loader', () => {
 	it('should wrap local exports with decorator', () => {
 		const content = `exports.locals = { "hello": "world" };`;
 
-		const result = loader.bind({ resourcePath: 'testFile.css' })(content);
+		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
 		assert.equal(result, 'exports.locals = {"hello":"world"," _key":"testFile"};');
 	});
 
@@ -24,7 +24,7 @@ describe('css-module-decorator-loader', () => {
 			"foo": "bar"
 		};`;
 
-		const result = loader.bind({ resourcePath: 'testFile.css' })(content);
+		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
 		assert.equal(result, 'exports.locals = {"hello":"world","foo":"bar"," _key":"testFile"};');
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Modifies the build command to process `.m.css` and leave `.css` files alone.

Resolves https://github.com/dojo/widgets/issues/76
