### PR TITLE
Add build option `target` to change webpack target between "web" and …

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -205,6 +205,11 @@ const command: Command = {
 			describe: 'Disable lazy widget loading detection',
 			type: 'boolean'
 		});
+
+		options('target', {
+			describe: 'Build target environment "web" (default) or "node"',
+			type: 'string'
+		});
 	},
 	run(helper: Helper, args: BuildArgs) {
 		const dojoRc = helper.configuration.get('build-webpack') || Object.create(null);

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -206,6 +206,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			filename: '[name].js',
 			chunkFilename: '[name].js'
 		},
+		target: args.target || 'web',
 		devtool: 'source-map',
 		resolve: {
 			modules: [

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -95,6 +95,16 @@ describe('main', () => {
 			options.args[ 8 ],
 			[ 'debug', { describe: 'Generate package information useful for debugging', type: 'boolean' } ]
 		);
+
+		assert.deepEqual(
+			options.args[ 9 ],
+			[ 'disableLazyWidgetDetection', { describe: 'Disable lazy widget loading detection', type: 'boolean' } ]
+		);
+
+		assert.deepEqual(
+			options.args[ 10 ],
+			[ 'target', { describe: 'Build target environment "web" (default) or "node"', type: 'string' } ]
+		);
 	});
 
 	it('should run compile and log results on success', () => {


### PR DESCRIPTION
The builder is not setting Webpack's `target` option and the default is "web" which builds chunks for the browser environment.  Using `@dojo/core/load` causes  Webpack to inject code into the chunks that assumes the global `window` exists.  This fails when the chunks are loaded in a node.js environment.

This PR adds a `target` option to the builder which maintains the "web" target by default.

Fix dojo/cli-test-intern#17

