### PR TITLE
Fix return type to be an array when using includeWhen

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -140,12 +140,12 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					filename: 'widget-core.js'
 				}) ];
 			}),
-			includeWhen(!args.watch && !args.withTests, (args) => {
-				return new webpack.optimize.UglifyJsPlugin({
+			...includeWhen(!args.watch && !args.withTests, (args) => {
+				return [ new webpack.optimize.UglifyJsPlugin({
 					sourceMap: true,
 					compress: { warnings: false },
 					exclude: /tests[/]/
-				});
+				}) ];
 			}),
 			includeWhen(args.element, args => {
 				return new HtmlWebpackPlugin({


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**
We should probably fix `includeWhen` as a follow up to be less surprising in behaviour.
