### PR TITLE
Add Dojo license to the top of all builds.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
     require('grunt-dojo2').initConfig(grunt, {
-        staticDefinitionFiles: ['**/*.d.ts', '**/*.html']
+        staticDefinitionFiles: ['**/*.d.ts', '**/*.html', '**/*.md']
     });
     grunt.registerTask('ci', [
         'intern:node'

--- a/src/banner.md
+++ b/src/banner.md
@@ -1,0 +1,4 @@
+[Dojo](https://dojo.io/)
+Copyright [JS Foundation](https://js.foundation/) & contributors
+[New BSD license](https://github.com/dojo/meta/blob/master/LICENSE)
+All rights reserved

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -1,7 +1,7 @@
 import webpack = require('webpack');
 import NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
 import * as path from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { BuildArgs } from './main';
 import Set from '@dojo/shim/Set';
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
@@ -102,6 +102,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			};
 		}),
 		plugins: [
+			new webpack.BannerPlugin(readFileSync(path.join(__dirname, './banner.md'), 'utf8')),
 			new IgnorePlugin(/request\/providers\/node/),
 			new NormalModuleReplacementPlugin(/\.m.css$/, result => {
 				const requestFileName = path.resolve(result.context, result.request);

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -60,6 +60,7 @@ declare module 'webpack' {
 }
 
 declare module 'webpack/lib/webpack' {
+	import WebpackBannerPlugin = require('webpack/lib/BannerPlugin');
 	import WebpackCompiler = require('webpack/lib/Compiler');
 	import WebpackContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
 	import WebpackNormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
@@ -69,9 +70,11 @@ declare module 'webpack/lib/webpack' {
 	function webpack(options: webpack.Config, callback?: Function): WebpackCompiler;
 
 	namespace webpack {
+		export type BannerPlugin = WebpackBannerPlugin;
 		export type Compiler = WebpackCompiler;
 		export type ContextReplacementPlugin = WebpackContextReplacementPlugin;
 		export type NormalModuleReplacementPlugin = WebpackNormalModuleReplacementPlugin;
+		export const BannerPlugin: typeof WebpackBannerPlugin;
 		export const Compiler: typeof WebpackCompiler;
 		export const ContextReplacementPlugin: typeof WebpackContextReplacementPlugin;
 		export const NormalModuleReplacementPlugin: typeof WebpackNormalModuleReplacementPlugin;
@@ -236,6 +239,25 @@ declare module 'webpack/lib/webpack' {
 	}
 
 	export = webpack;
+}
+
+declare module 'webpack/lib/BannerPlugin' {
+	import webpack = require('webpack');
+
+	interface BannerOptions {
+		banner: string;
+		entryOnly: boolean;
+		exclude: string | RegExp | (string | RegExp)[];
+		include: string | RegExp | (string | RegExp)[];
+		raw: boolean;
+		test: string | RegExp | (string | RegExp)[];
+	}
+
+	class BannerPlugin implements webpack.Plugin {
+		constructor(options: string | BannerOptions);
+		apply(compiler: webpack.Compiler): void;
+	}
+	export = BannerPlugin;
 }
 
 declare module 'webpack/lib/Chunk' {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add `src/banner.md` that contains any text (e.g., the Dojo license) that needs to be prepended as a comment to the output build source.

Resolves #108 
