### PR TITLE
CoreLoadPlugin: add option to map all app mids.

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -131,9 +131,10 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				]);
 			}),
 			new CoreLoadPlugin({
+				basePath,
 				detectLazyLoads: !args.disableLazyWidgetDetection,
 				ignoredModules,
-				basePath
+				mapAppModules: args.withTests
 			}),
 			...includeWhen(args.element, () => {
 				return [ new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Introduce a flag (set within the webpack config to true when `args.withTests` is true) to `CoreLoadPlugin` that allows all app modules to be added to the internal mid map, so that they can be lazy-loaded without parsing, as long as the modules have already been loaded by webpack.

Resolves #106
