### PR TITLE
Add option to reuse CLDR data from previous builds

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -163,9 +163,10 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				});
 			}),
 			...includeWhen(args.locale, args => {
-				const { locale, messageBundles, supportedLocales } = args;
+				const { locale, messageBundles, supportedLocales, watch } = args;
 				return [
 					new I18nPlugin({
+						cacheCldrUrls: watch,
 						defaultLocale: locale,
 						supportedLocales,
 						messageBundles


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

When running in `watch` mode, cache any CLDR data URLs parsed from previous builds in order to prevent future, partial builds from obliterating injected CLDR data.

The one downside to caching URLs is that any removed URLs will not be removed from the build until after a hard restart. But given that CLDR data will be rarely added or removed from a project, this is unlikely to be problematic.

Resolves #125 
