### PR TITLE
Update npm package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @dojo/cli-build
+# @dojo/cli-build-webpack
 
 [![Build Status](https://travis-ci.org/dojo/cli-build.svg?branch=master)](https://travis-ci.org/dojo/cli-build)
 [![codecov](https://codecov.io/gh/dojo/cli-build/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/cli-build)
@@ -20,21 +20,21 @@ The official dojo 2 build command.
 
 ## Usage
 
-To use `@dojo/cli-build` in a single project, install the package:
+To use `@dojo/cli-build-webpack` in a single project, install the package:
 
 ```bash
-npm install @dojo/cli-build
+npm install @dojo/cli-build-webpack
 ```
 
-to use `@dojo/cli-build` in every project, install the project globally:
+to use `@dojo/cli-build-webpack` in every project, install the project globally:
 
 ```bash
-npm install -g @dojo/cli-build
+npm install -g @dojo/cli-build-webpack
 ```
 
 ## Features
 
-`@dojo/cli-build` is an optional command for the [`@dojo/cli`](https://github.com/dojo/cli).
+`@dojo/cli-build-webpack` is an optional command for the [`@dojo/cli`](https://github.com/dojo/cli).
 
 ### Building
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -11,7 +11,7 @@ export const proxyUrl = 'http://localhost:9000/';
 // automatically
 export const capabilities = {
 	project: 'Dojo 2',
-	name: '@dojo/cli-build'
+	name: '@dojo/cli-build-webpack'
 };
 
 // Support running unit tests from a web server that isn't the intern proxy

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-	"name": "dojo-cli-build",
+	"name": "@dojo/cli-build-webpack",
 	"dependencies": {
 		"yargs": "registry:npm/yargs#5.0.0+20160817153026"
 	}


### PR DESCRIPTION
Following the `readme`, I ran into an error when trying to install the package with name: "@dojo/cli-build":
```
npm ERR! 404  '@dojo/cli-build' is not in the npm registry.
```
This PR updates the npm package name to what is currently [published on npm](https://www.npmjs.com/package/@dojo/cli-build-webpack).