### PR TITLE
Fix: do not reformat i18n args.

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -163,11 +163,10 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				});
 			}),
 			...includeWhen(args.locale, args => {
-				const supportedLocales = Array.isArray(args.supportedLocales) ? args.supportedLocales : [ args.supportedLocales ];
-				const messageBundles = Array.isArray(args.messageBundles) ? args.messageBundles : [ args.messageBundles ];
+				const { locale, messageBundles, supportedLocales } = args;
 				return [
 					new I18nPlugin({
-						defaultLocale: args.locale,
+						defaultLocale: locale,
 						supportedLocales,
 						messageBundles
 					})


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Remove additional (and incorrect) normalization of `args.supportedLocales` and `args.messageBundles` before passing them to `I18nPlugin`. Verified against `dojo/examples/todo-mvc-kitchensink`.

Resolves #140 
