### PR TITLE
Hotfix: use the correct path separator for imports-loader.

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -255,7 +255,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					}
 				]},
 				{ test: /\.js?$/, loader: 'umd-compat-loader' },
-				{ test: /globalize(\/|$)/, loader: 'imports-loader?define=>false' },
+				{ test: new RegExp(`globalize(\\${path.sep}|$)`), loader: 'imports-loader?define=>false' },
 				...includeWhen(!args.element, () => {
 					return [
 						{ test: /\.html$/, loader: 'html-loader' }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Update the path separator used in the regular expression that triggers the `imports-loader` on Globalize.js modules.

Fix verified on Windows 10.

Resolves #162 