### PR TITLE
Add worker-loader dependency to support web workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "umd-compat-loader": "^2.0.1",
     "webpack": "^2.2.1",
     "webpack-bundle-analyzer-sunburst": "^1.2.0",
-    "webpack-dev-server": "^2.3.0"
+    "webpack-dev-server": "^2.3.0",
+    "worker-loader": "^0.8.0"
   }
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding this dependency would allow the use of webworkers in a dojo app using this syntax
```typescript
const worker: Worker = new (require('worker-loader?name=hackerNewsWebWorker.js!./hackerNewsWebWorker'));
```

It works with a normal build or the dev server, and causes a separate compilation for the webworker. Dependencies can be pulled into the webworker and will be built into a separate bundle.
