### PR TITLE
Use different tsconfigs for building with and without tests

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -250,7 +250,8 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					{
 						loader: 'ts-loader',
 						options: {
-							instance: 'dojo'
+							instance: 'dojo',
+							configFileName: args.withTests ? 'tsconfig-tests.json' : 'tsconfig.json'
 						}
 					}
 				]},
@@ -272,7 +273,8 @@ function webpackConfig(args: Partial<BuildArgs>) {
 							{
 								loader: 'ts-loader',
 								options: {
-									instance: 'dojo'
+									instance: 'dojo',
+									configFileName: 'tsconfig-tests.json'
 								}
 							}
 						] }


### PR DESCRIPTION


The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This updates the build so that it uses separate tsconfig files for `dojo build` and `dojo build -t`. `dojo build` would use a tsconfig file that only compiles sources files, and the tsconfig file for `dojo build -t` would also compile tests. Relies on dojo/cli-create-app#89 to create the separate config files in a new project.
Resolves #113
